### PR TITLE
Avoid infinite loop on non-interactive install

### DIFF
--- a/src/Deeson/WardenBundle/Composer/ScriptHandler.php
+++ b/src/Deeson/WardenBundle/Composer/ScriptHandler.php
@@ -32,9 +32,11 @@ class ScriptHandler {
         $username = $output->ask('Please enter the admin username [admin]: ', 'admin');
       }
 
-      $password = '';
-      while (strlen($password) < 8) {
+      for ($password = '', $retries = 0; strlen($password) < 8 && $retries < 5; $retries++) {
         $password = $output->askAndHideAnswer('Please enter the admin password (minimum of 8 characters): ', '');
+      }
+      if (empty($password)) {
+        throw new \InvalidArgumentException('An admin password is required.');
       }
 
       $output->write(' - Setting up the password file ...');


### PR DESCRIPTION
On install, Warden asks for the admin password. If running `composer install --no-interaction`, the `ask()` method is presumably supposed to return the default. That works fine for the admin username, but here for the password Warden is rejecting its own default (an empty string), and looping infinitely. This PR ensures there won't be an infinite loop.