### PR TITLE
add drupal 9 support

### DIFF
--- a/src/Deeson/WardenDrupalBundle/Document/SiteDrupalDocument.php
+++ b/src/Deeson/WardenDrupalBundle/Document/SiteDrupalDocument.php
@@ -42,11 +42,13 @@ class SiteDrupalDocument extends BaseDocument {
    * @return string
    */
   public function getTypeImagePath() {
-    if ($this->getCoreVersion() < 8) {
-      return 'bundles/deesonwardendrupal/images/drupal7-logo.png';
-    }
+    // Grab first digits before first dot
+    preg_match("/^(\d)*?\./", $this->getCoreVersion(), $matches);
 
-    return 'bundles/deesonwardendrupal/images/drupal8-logo.png';
+    // If none found, defaults to drupal 8
+    $version = (isset($matches[1])) ? $matches[1] : 8;
+
+    return 'bundles/deesonwardendrupal/images/drupal' . $version . '-logo.png';
   }
 
   /**


### PR DESCRIPTION
Minor changes to enable drupal 9 updates. Update XML file for /9.x doesn't exist, needed to fallback to /current instead. This solution might be temporary but it works at the moment.